### PR TITLE
fix: support numpy 2.0 by removing deprecated APIs

### DIFF
--- a/kamodo/kamodo.py
+++ b/kamodo/kamodo.py
@@ -1527,7 +1527,7 @@ class Kamodo(UserDict):
             (10, 20, 50, 250)) # match coordinate arrays
 
         # define and kamodofy interpolating function
-        rgi = RegularGridInterpolator((t, lon, lat, ht), variable, bounds_error = False, fill_value=np.NaN)
+        rgi = RegularGridInterpolator((t, lon, lat, ht), variable, bounds_error = False, fill_value=np.nan)
 
         @kamodofy(units='m/s', data=variable)
         def interpolator(xvec):

--- a/kamodo/rpc/proto.py
+++ b/kamodo/rpc/proto.py
@@ -140,7 +140,7 @@ def to_rpc_literal(value):
     elif isinstance(value, float):
         # python standard float is C double
         which = 'float64'
-        value = float(value) # cast np.float as float
+        value = float(value) # cast numpy float as Python float
     elif isinstance(value, str):
         which = 'text'
     elif isinstance(value, list):

--- a/kamodo/util.py
+++ b/kamodo/util.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 import sympy
 from decorator import decorate
+import shlex
 import subprocess
 from scipy.integrate import solve_ivp
 from sympy import Add, Mul, Pow, Tuple, sympify
@@ -135,11 +136,12 @@ def compile_fortran(source, module_name, extra_args='', folder='./'):
         fortran_file.write(source)
         fortran_file.flush()
 
-        args = ' -c -m {} {} {}'.format(module_name, fortran_file.name,
-                                        extra_args)
-        command = 'cd "{}" && "{}" -c "import numpy.f2py as f2py;f2py.main()" {}'.format(
-            folder, sys.executable, args)
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        f2py_args = ["-c", "-m", module_name, fortran_file.name]
+        if extra_args:
+            f2py_args.extend(shlex.split(extra_args))
+        cmd = [sys.executable, "-c", "import numpy.f2py as f2py;f2py.main()"] + f2py_args
+        command = " ".join(shlex.quote(a) for a in cmd)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=folder)
         status = result.returncode
         output = result.stdout + result.stderr
         return status, output, command

--- a/kamodo/util.py
+++ b/kamodo/util.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import sympy
 from decorator import decorate
-from numpy.distutils.exec_command import exec_command
+import subprocess
 from scipy.integrate import solve_ivp
 from sympy import Add, Mul, Pow, Tuple, sympify
 from sympy import Function
@@ -139,7 +139,9 @@ def compile_fortran(source, module_name, extra_args='', folder='./'):
                                         extra_args)
         command = 'cd "{}" && "{}" -c "import numpy.f2py as f2py;f2py.main()" {}'.format(
             folder, sys.executable, args)
-        status, output = exec_command(command)
+        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        status = result.returncode
+        output = result.stdout + result.stderr
         return status, output, command
 
 


### PR DESCRIPTION
## Summary
- Replace `numpy.distutils.exec_command` with `subprocess.run` (removed in numpy 2.0)
- Replace `np.NaN` with `np.nan` (removed in numpy 2.0)
- Update comment referencing deprecated `np.float` alias
- Eliminate `shell=True` in subprocess call for security (use argument list + `cwd` instead)

Relates to nasa/Kamodo#154

## Changes
| File | Change |
|---|---|
| `kamodo/util.py` | `numpy.distutils.exec_command` → `subprocess.run` with argument list, `cwd=folder`, no `shell=True` |
| `kamodo/kamodo.py` | `np.NaN` → `np.nan` |
| `kamodo/rpc/proto.py` | Comment: `np.float` → `numpy float` |

## Context
`numpy.distutils` was removed in NumPy 2.0 ([migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html)). The `exec_command` function has been replaced with `subprocess.run` using an argument list (no `shell=True`) and `shlex.quote` for safe argument handling.

A companion PR for `kamodo_ccmc` (nasa/Kamodo#156) has also been submitted.